### PR TITLE
chore: bump plugin version to 2.1.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group = "io.snyk.code.sdk"
 archivesBaseName = "snyk-code-client"
-version = "2.1.6"
+version = "2.1.7"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
This PR bump the plugin version from `2.1.6` to `2.1.7`.