### PR TITLE
fix proceeding only configFiles files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.3.4] - 2022-05
+- update fallbacks for supported extensions and configFiles
+- change: provide ability to distinguish if supported file belong to supported extensions or configFiles 
+- fix: do not proceed (send) files if only configFiles (.gitignore or .dcignore) presence
+
 ## [2.3.3] - 2022-05
 - fix: recognition of bundle that contains no files
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group = "io.snyk.code.sdk"
 archivesBaseName = "snyk-code-client"
-version = "2.3.3"
+version = "2.3.4"
 
 repositories {
     mavenLocal()


### PR DESCRIPTION
fix: do not proceed (send) files if only configFiles (.gitignore or .dcignore) presence;
update fallbacks for supported extensions and configFiles;
change: provide ability to distinguish if supported file belong to supported extensions or configFiles.